### PR TITLE
force codahale tick to always be nanoseconds.

### DIFF
--- a/src/main/java/com/outbrain/swinfra/metrics/Summary.java
+++ b/src/main/java/com/outbrain/swinfra/metrics/Summary.java
@@ -212,9 +212,7 @@ public class Summary extends AbstractMetric<Histogram> implements TimingMetric {
 
     @Override
     public long getTick() {
-      return clock.getTick();
+      return clock.getTick(TimeUnit.NANOSECONDS);
     }
-
-
   }
 }

--- a/src/main/java/com/outbrain/swinfra/metrics/timing/Clock.java
+++ b/src/main/java/com/outbrain/swinfra/metrics/timing/Clock.java
@@ -7,6 +7,8 @@ public interface Clock {
 
   long getTick();
 
+  long getTick(TimeUnit timeunit);
+
   /**
    * A clock that uses System.nanoTime to measure its ticks.
    * Ticks are provided according the to given ticks unit, the default being nanoseconds.
@@ -35,5 +37,9 @@ public interface Clock {
       return (long) (System.nanoTime() * factor);
     }
 
+    @Override
+    public long getTick(final TimeUnit ticksUnit) {
+      return ticksUnit.convert(System.nanoTime(), TimeUnit.NANOSECONDS);
+    }
   }
 }

--- a/src/test/groovy/com/outbrain/swinfra/metrics/TestClock.groovy
+++ b/src/test/groovy/com/outbrain/swinfra/metrics/TestClock.groovy
@@ -2,6 +2,8 @@ package com.outbrain.swinfra.metrics
 
 import com.outbrain.swinfra.metrics.timing.Clock
 
+import java.util.concurrent.TimeUnit
+
 class TestClock extends com.codahale.metrics.Clock implements Clock {
 
     private long tick = 0
@@ -12,6 +14,11 @@ class TestClock extends com.codahale.metrics.Clock implements Clock {
 
     @Override
     long getTick() {
+        return tick
+    }
+
+    @Override
+    long getTick(final TimeUnit timeunit) {
         return tick
     }
 


### PR DESCRIPTION
reservoir expect nanosecond ticks (or at least ticks that change at roughly nanosecond pace - That's the only way their CPU cycle clock can work).

We make sure with this fix - that this is what we pass the reservoir. 
I think this fits the bug we see. It used to be a bug in Gauge as well when we used CachedGauge (which internally also uses a clock). But that's changed now so we see the issue only in Summary.
 