### PR TITLE
Use HdrHistogram to implement summary instead of drop wizard's reservoir

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ environment. Thread-safety is key and the performance impact of using metrics mu
 
 When reviewing the official Prometheus client we discovered a several *synchronized* blocks that in the *Summary* and *Gauge*
 metric types. In order to avoid the [contention](http://www.ibm.com/developerworks/library/j-threads2/) we decided to write our own client, 
-wrapping dropwizard-metrics internally, with a custom Bucket-based 
+wrapping HdrHistogram and dropwizard-metrics internally, with a custom Bucket-based 
 [Histogram](https://github.com/outbrain/prometheus-client/blob/master/src/main/java/com/outbrain/swinfra/metrics/Histogram.java) implementation.
 
 ## Getting Started
@@ -169,17 +169,16 @@ registry.getOrRegister(new GaugeBuilder("name", "help").withLabels("label1")
 ```
 
 ### Summary - Advanced
-The *Summary* metric support the different types of reservoirs that DropWizard supports. They can be used like so:
+*Summary* supports different precisions.
 
-The default reservoir is the exponentially decaying reservoir.
 ```java
-Summary summary = registry.getOrRegister(new SummaryBuilder("name", "help").withReservoir()
-                                                 .withUniformReservoir(100)
-                                                 .build());
+Summary summary = registry.getOrRegister(new SummaryBuilder("name", "help")
+                                              .withNumberOfSignificantValueDigits(3)
+                                              .build());
 ```
 
 ### Histogram - Advanced
-The *Histogram* can be configured with custom buckets or with equal width buckets at a given range.
+*Histogram* can be configured with custom buckets or with equal width buckets at a given range.
 ```java
 //Custom buckets
 Histogram histo = registry.getOrRegister(new HistogramBuilder("name", "help")
@@ -193,7 +192,7 @@ Histogram histo = registry.getOrRegister(new HistogramBuilder("name", "help").wi
 ```
 
 ### Timer - Advanced
-The *Timer* supports custom clocks, with the default being the system clock which measures intervals
+*Timer* supports custom clocks, with the default being the system clock which measures intervals
 according to *System.nanoTime()*.
 
 This example shows a timer over a *Histogram* metric, but it's also applicable to the *Summary* metric

--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,8 @@ dependencies {
     compile(
         'io.dropwizard.metrics:metrics-core:3.1.2',
         'org.apache.commons:commons-lang3:3.3.2',
-        'com.google.protobuf:protobuf-java:2.6.1'
+        'com.google.protobuf:protobuf-java:2.6.1',
+        'org.hdrhistogram:HdrHistogram:2.1.10'
     )
 
     testCompile(
@@ -36,7 +37,6 @@ dependencies {
         'org.openjdk.jmh:jmh-generator-annprocess:0.9',
         'io.prometheus:simpleclient:0.0.18',
         'io.prometheus:simpleclient_common:0.0.18',
-        'org.hdrhistogram:HdrHistogram:2.1.8'
     )
 }
 

--- a/src/main/java/com/outbrain/swinfra/metrics/Summary.java
+++ b/src/main/java/com/outbrain/swinfra/metrics/Summary.java
@@ -1,25 +1,16 @@
 package com.outbrain.swinfra.metrics;
 
-import com.codahale.metrics.ExponentiallyDecayingReservoir;
-import com.codahale.metrics.Histogram;
-import com.codahale.metrics.Reservoir;
-import com.codahale.metrics.SlidingTimeWindowReservoir;
-import com.codahale.metrics.SlidingWindowReservoir;
-import com.codahale.metrics.Snapshot;
-import com.codahale.metrics.UniformReservoir;
 import com.outbrain.swinfra.metrics.children.ChildMetricRepo;
 import com.outbrain.swinfra.metrics.children.LabeledChildrenRepo;
 import com.outbrain.swinfra.metrics.children.MetricData;
 import com.outbrain.swinfra.metrics.children.UnlabeledChildRepo;
+import com.outbrain.swinfra.metrics.data.HistogramWithRunningCountAndSum;
 import com.outbrain.swinfra.metrics.data.MetricDataConsumer;
-import com.outbrain.swinfra.metrics.data.SummaryData;
 import com.outbrain.swinfra.metrics.timing.Clock;
 import com.outbrain.swinfra.metrics.timing.Timer;
 import com.outbrain.swinfra.metrics.timing.TimingMetric;
 import com.outbrain.swinfra.metrics.utils.MetricType;
-
-import java.util.concurrent.TimeUnit;
-import java.util.function.Supplier;
+import org.HdrHistogram.Recorder;
 
 import static com.outbrain.swinfra.metrics.timing.Clock.DEFAULT_CLOCK;
 import static com.outbrain.swinfra.metrics.utils.MetricType.SUMMARY;
@@ -47,29 +38,28 @@ import static com.outbrain.swinfra.metrics.utils.MetricType.SUMMARY;
  * @see <a href="https://prometheus.io/docs/concepts/metric_types/#summary">Prometheus summary metric</a>
  * @see <a href="https://prometheus.io/docs/practices/histograms/">Prometheus summary vs. histogram</a>
  */
-public class Summary extends AbstractMetric<Histogram> implements TimingMetric {
+public class Summary extends AbstractMetric<HistogramWithRunningCountAndSum> implements TimingMetric {
 
-
-  private final Supplier<Reservoir> reservoirSupplier;
   private final Clock clock;
+  private final int numberOfSignificantValueDigits;
 
   private Summary(final String name,
                   final String help,
                   final String[] labelNames,
-                  final Supplier<Reservoir> reservoirSupplier,
-                  final Clock clock) {
+                  final Clock clock,
+                  final int numberOfSignificantValueDigits) {
     super(name, help, labelNames);
-    this.reservoirSupplier = reservoirSupplier;
     this.clock = clock;
+    this.numberOfSignificantValueDigits = numberOfSignificantValueDigits;
   }
 
   public void observe(final long value, final String... labelValues) {
     validateLabelValues(labelValues);
-    metricForLabels(labelValues).update(value);
+    metricForLabels(labelValues).recordValue(value);
   }
 
   @Override
-  ChildMetricRepo<Histogram> createChildMetricRepo() {
+  ChildMetricRepo<HistogramWithRunningCountAndSum> createChildMetricRepo() {
     if (getLabelNames().isEmpty()) {
       return new UnlabeledChildRepo<>(new MetricData<>(createHistogram()));
     } else {
@@ -77,8 +67,8 @@ public class Summary extends AbstractMetric<Histogram> implements TimingMetric {
     }
   }
 
-  private Histogram createHistogram() {
-    return new Histogram(reservoirSupplier.get());
+  private HistogramWithRunningCountAndSum createHistogram() {
+    return new HistogramWithRunningCountAndSum(new Recorder(Long.MAX_VALUE, numberOfSignificantValueDigits));
   }
 
   @Override
@@ -88,27 +78,19 @@ public class Summary extends AbstractMetric<Histogram> implements TimingMetric {
 
   @Override
   public void forEachMetricData(final MetricDataConsumer consumer) {
-    forEachChild(metricData -> {
-      final CodahaleSummaryData snapshot = new CodahaleSummaryData(metricData.getMetric().getCount(), metricData.getMetric().getSnapshot());
-      consumer.consumeSummary(this, metricData.getLabelValues(), snapshot);
-    });
+    forEachChild(metricData -> consumer.consumeSummary(this, metricData.getLabelValues(), metricData.getMetric().summary()));
   }
 
   @Override
   public Timer startTimer(final String... labelValues) {
-    final Histogram histogram = metricForLabels(labelValues);
-    return new Timer(clock, histogram::update);
+    final HistogramWithRunningCountAndSum histogram = metricForLabels(labelValues);
+    return new Timer(clock, histogram::recordValue);
   }
 
   public static class SummaryBuilder extends AbstractMetricBuilder<Summary, SummaryBuilder> {
 
-    private static final int DEFAULT_SIZE = 1028;
-    private static final double DEFAULT_ALPHA = 0.015;
-
     private Clock clock = DEFAULT_CLOCK;
-    private com.codahale.metrics.Clock codahaleClock = toCodahaleClock(DEFAULT_CLOCK);
-    private Supplier<Reservoir> reservoirSupplier = () -> new ExponentiallyDecayingReservoir(DEFAULT_SIZE, DEFAULT_ALPHA,
-                                                                                             codahaleClock);
+    private int numberOfSignificantValueDigits = 2;
 
     public SummaryBuilder(final String name, final String help) {
       super(name, help);
@@ -116,158 +98,18 @@ public class Summary extends AbstractMetric<Histogram> implements TimingMetric {
 
     public SummaryBuilder withClock(final Clock clock) {
       this.clock = clock;
-      this.codahaleClock = toCodahaleClock(clock);
       return this;
     }
 
-    public ReservoirBuilder withReservoir() {
-      return new ReservoirBuilder();
-    }
-
-    public class ReservoirBuilder {
-
-      /**
-       * Create this summary with an exponentially decaying reservoir - a reservoir that gives a lower
-       * importance to older measurements with default size and alpha.
-       *
-       * @see <a href="http://dimacs.rutgers.edu/~graham/pubs/papers/fwddecay.pdf">
-       */
-      public SummaryBuilder withExponentiallyDecayingReservoir() {
-        return withExponentiallyDecayingReservoir(DEFAULT_SIZE, DEFAULT_ALPHA);
-      }
-
-      /**
-       * Create this summary with an exponentially decaying reservoir - a reservoir that gives a lower
-       * importance to older measurements.
-       *
-       * @param size  the size of the reservoir - the number of measurements that will be saved
-       * @param alpha the exponential decay factor. The higher this is the more biased the reservoir will
-       *              be towards newer measurements.
-       * @see <a href="http://dimacs.rutgers.edu/~graham/pubs/papers/fwddecay.pdf">
-       */
-      public SummaryBuilder withExponentiallyDecayingReservoir(final int size, final double alpha) {
-        reservoirSupplier = () -> new ExponentiallyDecayingReservoir(size, alpha, codahaleClock);
-        return SummaryBuilder.this;
-      }
-
-      /**
-       * Create this summary with a sliding time window reservoir. This reservoir keeps the measurements made in the
-       * last {@code window} seconds (or other time unit).
-       *
-       * @param window     the window to save
-       * @param windowUnit the window's time units
-       */
-      public SummaryBuilder withSlidingTimeWindowReservoir(final int window, final TimeUnit windowUnit) {
-        reservoirSupplier = () -> new SlidingTimeWindowReservoir(window, windowUnit, codahaleClock);
-        return SummaryBuilder.this;
-      }
-
-      /**
-       * Create this summary with a sliding window reservoir. This reservoir keeps a constant amount of the last
-       * measurements and is therefore memory-bound.
-       *
-       * @param size the number of measurements to save
-       */
-      public SummaryBuilder withSlidingWindowReservoir(final int size) {
-        reservoirSupplier = () -> new SlidingWindowReservoir(size);
-        return SummaryBuilder.this;
-      }
-
-
-      /**
-       * Create this summary with a uniform reservoir - a reservoir that randomally saves the measurements and is
-       * statistically representative of all measurements.
-       *
-       * @param size the size of the reservoir - the number of measurements that will be saved
-       * @see <a href="http://www.cs.umd.edu/~samir/498/vitter.pdf">Random Sampling with a Reservoir</a>
-       */
-      public SummaryBuilder withUniformReservoir(final int size) {
-        reservoirSupplier = () -> new UniformReservoir(size);
-        return SummaryBuilder.this;
-      }
+    public SummaryBuilder withNumberOfSignificantValueDigits(final int numberOfSignificantValueDigits) {
+      this.numberOfSignificantValueDigits = numberOfSignificantValueDigits;
+      return this;
     }
 
     @Override
     protected Summary create(final String fullName, final String help, final String[] labelNames) {
-      return new Summary(fullName, help, labelNames, reservoirSupplier, clock);
+      return new Summary(fullName, help, labelNames, clock, numberOfSignificantValueDigits);
     }
   }
 
-  private static com.codahale.metrics.Clock toCodahaleClock(final Clock clock) {
-    if (clock instanceof com.codahale.metrics.Clock) {
-      return (com.codahale.metrics.Clock) clock;
-    }
-    return new CodahaleClockAdapter(clock);
-  }
-
-  private static class CodahaleClockAdapter extends com.codahale.metrics.Clock {
-
-    private final Clock clock;
-
-    CodahaleClockAdapter(final Clock clock) {
-      this.clock = clock;
-    }
-
-    @Override
-    public long getTick() {
-      return clock.getTick(TimeUnit.NANOSECONDS);
-    }
-  }
-
-  private static class CodahaleSummaryData implements SummaryData {
-
-    private final long count;
-    private final Snapshot snapshot;
-    private long sum;
-
-
-    private CodahaleSummaryData(final long count, final Snapshot snapshot) {
-      this.count = count;
-      this.snapshot = snapshot;
-      sum = 0;
-      for (final long value : snapshot.getValues()) {
-        sum += value;
-      }
-    }
-
-    @Override
-    public long getCount() {
-      return count;
-    }
-
-    @Override
-    public double getSum() {
-      return sum;
-    }
-
-    @Override
-    public double getMedian() {
-      return snapshot.getMedian();
-    }
-
-    @Override
-    public double get75thPercentile() {
-      return snapshot.get75thPercentile();
-    }
-
-    @Override
-    public double get95thPercentile() {
-      return snapshot.get95thPercentile();
-    }
-
-    @Override
-    public double get98thPercentile() {
-      return snapshot.get98thPercentile();
-    }
-
-    @Override
-    public double get99thPercentile() {
-      return snapshot.get99thPercentile();
-    }
-
-    @Override
-    public double get999thPercentile() {
-      return snapshot.get999thPercentile();
-    }
-  }
 }

--- a/src/main/java/com/outbrain/swinfra/metrics/data/HistogramWithRunningCountAndSum.java
+++ b/src/main/java/com/outbrain/swinfra/metrics/data/HistogramWithRunningCountAndSum.java
@@ -1,0 +1,109 @@
+package com.outbrain.swinfra.metrics.data;
+
+import org.HdrHistogram.Histogram;
+import org.HdrHistogram.HistogramIterationValue;
+import org.HdrHistogram.Recorder;
+
+/**
+ * Created by ahadadi on 26/04/2018.
+ */
+public class HistogramWithRunningCountAndSum {
+  private final Recorder recorder;
+  private Histogram histogramToRecycle;
+  private long count;
+  private long sum;
+
+  public HistogramWithRunningCountAndSum(final Recorder recorder) {
+    this.recorder = recorder;
+  }
+
+  public void recordValue(final long value) {
+    recorder.recordValue(value);
+  }
+
+  public synchronized SummaryData summary() {
+    histogramToRecycle = recorder.getIntervalHistogram(histogramToRecycle);
+    count += histogramToRecycle.getTotalCount();
+
+    HistogramIterationValue lastRecordedValue = null;
+    for (final HistogramIterationValue x : histogramToRecycle.recordedValues()) {
+      lastRecordedValue = x;
+    }
+    if (lastRecordedValue != null) {
+      sum += lastRecordedValue.getTotalValueToThisValue();
+    }
+
+    return new HdrSummaryData(histogramToRecycle, count, sum);
+  }
+
+  private static class HdrSummaryData implements SummaryData {
+
+    private final long count;
+    private final long sum;
+    private final long p50;
+    private final long p75;
+    private final long p95;
+    private final long p98;
+    private final long p99;
+    private final long p999;
+
+    private HdrSummaryData(final Histogram histogram, final long count, final long sum) {
+      this.count = count;
+      this.sum = sum;
+      this.p50 = histogram.getValueAtPercentile(50);
+      this.p75 = histogram.getValueAtPercentile(75);
+      this.p95 = histogram.getValueAtPercentile(95);
+      this.p98 = histogram.getValueAtPercentile(98);
+      this.p99 = histogram.getValueAtPercentile(99);
+      this.p999 = histogram.getValueAtPercentile(99.9);
+    }
+
+    @Override
+    public long getCount() {
+      return count;
+    }
+
+    @Override
+    public double getSum() {
+      return sum;
+    }
+
+    @Override
+    public double getMedian() {
+      return p50;
+    }
+
+    @Override
+    public double get75thPercentile() {
+      return p75;
+    }
+
+    @Override
+    public double get95thPercentile() {
+      return p95;
+    }
+
+    @Override
+    public double get98thPercentile() {
+      return p98;
+    }
+
+    @Override
+    public double get99thPercentile() {
+      return p99;
+    }
+
+    @Override
+    public double get999thPercentile() {
+      return p999;
+    }
+
+    @Override
+    public String toString() {
+      return String.format("count %d, sum %f, median %f, 75p %f, 95p %f, 98p %f, 99p %f, 999p %f",
+              getCount(), getSum(), getMedian(), get75thPercentile(), get95thPercentile(),
+              get98thPercentile(), get99thPercentile(), get999thPercentile());
+    }
+  }
+
+}

--- a/src/perf/java/com/outbrain/swinfra/metrics/SummaryThroughputTest.java
+++ b/src/perf/java/com/outbrain/swinfra/metrics/SummaryThroughputTest.java
@@ -7,68 +7,87 @@ import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Threads;
 
 import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
-@State(Scope.Thread)
+@Threads(Threads.MAX)
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
 public class SummaryThroughputTest {
 
-  private static final int NUM_OF_ITERATIONS = 10000;
+  private static final int NUM_OF_ITERATIONS = 10_000;
   private static final String[] LABEL_NAMES = {"label1", "label2"};
   private static final List<String[]> LABEL_VALUES = Arrays.asList(new String[]{"val1", "val2"},
-                                                                   new String[]{"val3", "val4"},
-                                                                   new String[]{"val5", "val6"},
-                                                                   new String[]{"val7", "val8"},
-                                                                   new String[]{"val9", "val10"},
-                                                                   new String[]{"val11", "val12"},
-                                                                   new String[]{"val13", "val14"},
-                                                                   new String[]{"val15", "val16"},
-                                                                   new String[]{"val17", "val18"},
-                                                                   new String[]{"val19", "val20"});
+          new String[]{"val3", "val4"},
+          new String[]{"val5", "val6"},
+          new String[]{"val7", "val8"},
+          new String[]{"val9", "val10"},
+          new String[]{"val11", "val12"},
+          new String[]{"val13", "val14"},
+          new String[]{"val15", "val16"},
+          new String[]{"val17", "val18"},
+          new String[]{"val19", "val20"});
 
-  private Summary summary;
-  private io.prometheus.client.Summary promSummary;
+  @State(Scope.Benchmark)
+  public static class PrometheusSummaryState {
+    private io.prometheus.client.Summary summary = prometheusSummary().create();
+  }
+
+  @State(Scope.Benchmark)
+  public static class LabeledPrometheusSummaryState {
+    private io.prometheus.client.Summary summary = prometheusSummary().labelNames(LABEL_NAMES).create();
+  }
+
+  private static io.prometheus.client.Summary.Builder prometheusSummary() {
+    return io.prometheus.client.Summary.build().
+            quantile(0.5, 0.1).
+            quantile(0.75, 0.1).
+            quantile(0.95, 0.1).
+            quantile(0.98, 0.01).
+            quantile(0.99, 0.01).
+            quantile(0.999, 0.001).
+            name("name").help("help");
+  }
+
   //todo validate end result
+  @State(Scope.Benchmark)
+  public static class SummaryState {
+    private Summary summary = new SummaryBuilder("name", "help").build();
+  }
+
+  @State(Scope.Benchmark)
+  public static class LabeledSummaryState {
+    private Summary summary = new SummaryBuilder("name", "help").withLabels("label1", "label2").build();
+  }
 
   @Benchmark
-  @BenchmarkMode(Mode.Throughput)
-  @OutputTimeUnit(TimeUnit.MILLISECONDS)
-  public void measureSimpleClientSummaryThroughput() {
-    promSummary = io.prometheus.client.Summary.build().name("name").help("help").create();
+  public void measurePrometheusSummaryThroughput(final PrometheusSummaryState summary) {
     for (int i = 0; i < NUM_OF_ITERATIONS; i++) {
-      promSummary.observe(i);
+      summary.summary.observe(i);
     }
   }
 
   @Benchmark
-  @BenchmarkMode(Mode.Throughput)
-  @OutputTimeUnit(TimeUnit.MILLISECONDS)
-  public void measureSimpleClientSummaryThroughputWithLabels() {
-    promSummary = io.prometheus.client.Summary.build().name("name").help("help").labelNames(LABEL_NAMES).create();
+  public void measurePrometheusSummaryThroughputWithLabels(final LabeledPrometheusSummaryState summary) {
     for (int i = 0; i < NUM_OF_ITERATIONS; i++) {
-      promSummary.labels(LABEL_VALUES.get(i % LABEL_VALUES.size())).observe(i);
+      summary.summary.labels(LABEL_VALUES.get(i % LABEL_VALUES.size())).observe(i);
     }
   }
 
   @Benchmark
-  @BenchmarkMode(Mode.Throughput)
-  @OutputTimeUnit(TimeUnit.MILLISECONDS)
-  public void measureSummaryThroughput() {
-    summary = new SummaryBuilder("name", "help").build();
+  public void measureSummaryThroughput(final SummaryState summary) {
     for (int i = 0; i < NUM_OF_ITERATIONS; i++) {
-      summary.observe(i);
+      summary.summary.observe(i);
     }
   }
 
   @Benchmark
-  @BenchmarkMode(Mode.Throughput)
-  @OutputTimeUnit(TimeUnit.MILLISECONDS)
-  public void measureSummaryThroughputWithLabels() {
-    summary = new SummaryBuilder("name", "help").withReservoir().withUniformReservoir(1000).withLabels("label1", "label2").build();
+  public void measureSummaryThroughputWithLabels(final LabeledSummaryState summary) {
     for (int i = 0; i < NUM_OF_ITERATIONS; i++) {
-      summary.observe(i, LABEL_VALUES.get(i % LABEL_VALUES.size()));
+      summary.summary.observe(i, LABEL_VALUES.get(i % LABEL_VALUES.size()));
     }
   }
 


### PR DESCRIPTION
HdrHistogram has 8x the throughput (tested with the project's JMH tests) vs drop wizard's Exponentially Decaying Reservoir which we currently use.
Also recording and snapshot do zero allocation in contrast to drop wizard. All used memory is pinned.